### PR TITLE
docs(nuxt-feather-icons): Add prefix configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ export default defineNuxtConfig({
   modules: [
     'nuxt-feather-icons'
   ],
-    nuxtFeatherIcons: {
-        // optional prefix for icons
-        prefix: 'Fi'
-    }
+  nuxtFeatherIcons: {
+    // optional prefix for icons
+    prefix: 'Fi'
+  }
 })
 ```
 Feather Icons are automatically registered as components. You can use any icon like `<HomeIcon />`.


### PR DESCRIPTION
- Add nuxtFeatherIcons configuration example
- Show how to use the optional prefix option

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an example configuration for the nuxtFeatherIcons option showing an optional prefix field (e.g., "Fi") to illustrate how to customize icon prefixes in your Nuxt config. No runtime behavior or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->