### PR TITLE
docs(nuxt-feather-icons): add provider option and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,18 +48,40 @@ npx nuxi@latest module add nuxt-feather-icons
 
 ```typescript
 export default defineNuxtConfig({
-  modules: ['nuxt-feather-icons'],
+    modules: ['nuxt-feather-icons'],
     nuxtFeatherIcons: {
-        // Prefix for icon components (e.g. <FHomeIcon />)
+        /**
+         * The icon library provider to use.
+         * 'feather' for classic Feather Icons.
+         * 'lucide' for the modern Lucide fork (more icons).
+         * @default 'lucide'
+         */
+        provider: 'lucide',
+
+        /**
+         * Prefix for icon components.
+         * Example: prefix: 'F' will generate <FHomeIcon />
+         * @default ''
+         */
         prefix: 'F',
 
-        // Global default size (string or number)
+        /**
+         * Global default size.
+         * Supports numbers (px) or strings like '1.5x' (em).
+         * @default 24
+         */
         size: 24,
 
-        // Global default stroke width
+        /**
+         * Global default stroke width.
+         * @default 2
+         */
         strokeWidth: 2,
 
-        // Global default CSS classes
+        /**
+         * Global default CSS classes added to every icon.
+         * @default ''
+         */
         class: 'my-default-icon-class'
     }
 })

--- a/docs/content/1.getting-started/2.installation.md
+++ b/docs/content/1.getting-started/2.installation.md
@@ -81,8 +81,8 @@ export default defineNuxtConfig({
 ---
 
 > [!TIP]
-> **Migrating from a previous version?** > If you are updating and want to keep your existing icons exactly as they were, set the `provider` to `'feather'` in your configuration. This ensures 100% backward compatibility with your current icon set and naming.
-
+> **Migrating from a previous version?**
+> If you are updating and want to keep your existing icons exactly as they were, set the `provider` to `'feather'` in your configuration. This ensures 100% backward compatibility with your current icon set and naming.
 
 ## Why PNPM?
 Since this module relies on high-performance tree-shaking and a virtual mapping strategy, 

--- a/docs/content/1.getting-started/2.installation.md
+++ b/docs/content/1.getting-started/2.installation.md
@@ -32,45 +32,57 @@ export default defineNuxtConfig({
 ```
 
 ## Configuration
-Nuxt Feather Icons works out of the box with zero configuration. However, you can customize the global behavior, such as component prefixes and default styles, in your `nuxt.config.ts`:
+Nuxt Feather Icons is designed to be plug-and-play. If you want to switch providers or set global styles, customize the nuxtFeatherIcons property in your `nuxt.config.ts`:
 
 ```typescript [nuxt.config.ts]
 export default defineNuxtConfig({
-  modules: [
-    'nuxt-feather-icons'
-  ],
+    modules: [
+        'nuxt-feather-icons'
+    ],
 
-  // Optional: Module configuration
     nuxtFeatherIcons: {
         /**
-         * Add a prefix to all icon components.
-         * Default: ''
-         * Example: 'F' will turn <HomeIcon /> into <FHomeIcon />
+         * The icon library provider to use.
+         * 'feather': The classic, minimalist Feather Icons.
+         * 'lucide': The modern, expanded fork with 1,000+ icons.
+         * @default 'lucide'
+         */
+        provider: 'lucide',
+
+        /**
+         * Add a prefix to all icon components to avoid naming conflicts.
+         * Example: 'Base' will turn <HomeIcon /> into <BaseHomeIcon />
+         * @default ''
          */
         prefix: '',
 
         /**
-         * Default icon size.
-         * Supports numbers (px) or strings (2x, 1.5rem, 100%).
-         * Default: 24
+         * Global default size.
+         * Supports numbers (px) or strings (e.g., '1.5x', '2rem', '100%').
+         * @default 24
          */
         size: 24,
 
         /**
-         * Default stroke width.
-         * Default: 2
+         * Default stroke width (thickness).
+         * @default 2
          */
         strokeWidth: 2,
 
         /**
-         * Default CSS classes applied to every icon.
-         * Perfect for global styling or Tailwind colors.
-         * Default: ''
+         * Global CSS classes applied to every icon element.
+         * Ideal for utility-first frameworks like Tailwind CSS.
+         * @default ''
          */
         class: ''
     }
 })
 ```
+---
+
+> [!TIP]
+> **Migrating from a previous version?** > If you are updating and want to keep your existing icons exactly as they were, set the `provider` to `'feather'` in your configuration. This ensures 100% backward compatibility with your current icon set and naming.
+
 
 ## Why PNPM?
 Since this module relies on high-performance tree-shaking and a virtual mapping strategy, 

--- a/docs/content/1.getting-started/3.icons.md
+++ b/docs/content/1.getting-started/3.icons.md
@@ -1,6 +1,6 @@
 ---
 title: Icons Gallery
-description: Explore all 280+ available icons in Nuxt Feather Icons.
+description: Browse and search through 1,000+ icons from Feather and Lucide providers.
 navigation:
   title: Icons Gallery
   icon: GridIcon

--- a/docs/package.json
+++ b/docs/package.json
@@ -21,7 +21,7 @@
     "@nuxt/image": "^2.0.0",
     "@nuxt/ui": "^4.5.0",
     "nuxt": "^4.3.1",
-    "nuxt-feather-icons": "^1.4.0",
+    "nuxt-feather-icons": "^1.4.2",
     "nuxt-llms": "^0.2.0",
     "nuxt-og-image": "^5.1.13"
   },

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^4.3.1
         version: 4.3.1(@parcel/watcher@2.5.6)(@types/node@25.4.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(terser@5.46.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.2))(vue-tsc@3.2.5(typescript@5.9.3))(yaml@2.8.2)
       nuxt-feather-icons:
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: ^1.4.2
+        version: 1.4.2
       nuxt-llms:
         specifier: ^0.2.0
         version: 0.2.0(magicast@0.5.2)
@@ -4319,6 +4319,9 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lucide@0.577.0:
+    resolution: {integrity: sha512-PpC/m5eOItp/WU/GlQPFBXDOhq6HibL73KzYP37OX3LM7VmzWQF8voEj8QRWUFvy9FIKfeDQkWYoyS1D/MdWFA==}
+
   magic-regexp@0.10.0:
     resolution: {integrity: sha512-Uly1Bu4lO1hwHUW0CQeSWuRtzCMNO00CmXtS8N6fyvB3B979GOEEeAkiTUDsmbYLAbvpUS/Kt5c4ibosAzVyVg==}
 
@@ -4655,8 +4658,8 @@ packages:
     resolution: {integrity: sha512-2/mSSqutOX8t+r8cAX1yUYwAPBqicPO5Rfum3XaHVszxKCF4tXEXBiPGfJY9Zn69x/CIeOdw+aM9wmHzQ5Q+lA==}
     hasBin: true
 
-  nuxt-feather-icons@1.4.0:
-    resolution: {integrity: sha512-kqYila1jrEyGYVwjmhQc2P9E3gzxjpp27317JXB20NHrEwUztBrTGZbyKLwyj5sD3/cddLsymUEpkK2AeNlXeQ==}
+  nuxt-feather-icons@1.4.2:
+    resolution: {integrity: sha512-ua7z7BAoC04imyxGnkOFvFcl+AeCS2ctz3DKB5iBc+CW+uNzxNpMD6mMEy1WOLNzf0zSENU3C7BzfCd8TDqY9A==}
 
   nuxt-llms@0.2.0:
     resolution: {integrity: sha512-GoEW00x8zaZ1wS0R0aOYptt3b54JEaRwlyVtuAiQoH51BwYdjN5/3+00/+4wi39M5cT4j5XcnGwOxJ7v4WVb9A==}
@@ -10828,6 +10831,8 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lucide@0.577.0: {}
+
   magic-regexp@0.10.0:
     dependencies:
       estree-walker: 3.0.3
@@ -11430,9 +11435,10 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  nuxt-feather-icons@1.4.0:
+  nuxt-feather-icons@1.4.2:
     dependencies:
       feather-icons: 4.29.2
+      lucide: 0.577.0
 
   nuxt-llms@0.2.0(magicast@0.5.2):
     dependencies:


### PR DESCRIPTION
- Add documentation for the new `provider` option ('feather' or 'lucide')
- Update installation guide to describe the module as 'plug-and-play'
- Update icon descriptions to reflect 1,000+ available icons from providers
- Update README configuration examples with JSDoc comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guide with new provider configuration option supporting Lucide and Feather icon libraries.
  * Added configurable options: prefix, size, strokeWidth, and class with detailed documentation.
  * Expanded icon gallery from 280+ to 1,000+ available icons.
  * Included migration guidance for backward compatibility.

* **Chores**
  * Updated dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->